### PR TITLE
Added second check of existing tenant

### DIFF
--- a/src/main/java/com/sunitkatkar/blogspot/tenant/config/DataSourceBasedMultiTenantConnectionProviderImpl.java
+++ b/src/main/java/com/sunitkatkar/blogspot/tenant/config/DataSourceBasedMultiTenantConnectionProviderImpl.java
@@ -96,6 +96,15 @@ public class DataSourceBasedMultiTenantConnectionProviderImpl
                         DataSourceUtil.createAndConfigureDataSource(masterTenant));
             }
         }
+            //check again if tenant exist in map after rescan master_db, if not, throw UsernameNotFoundException
+                    if (!this.dataSourcesMtApp.containsKey(tenantIdentifier)) {
+            LOG.warn("Trying to get tenant:" + tenantIdentifier + " which was not found in master db after rescan");
+            throw new UsernameNotFoundException(
+                    String.format(
+                            "Tenant not found after rescan, "
+                                    + " tenant=%s",
+                             tenantIdentifier));
+        }
         return this.dataSourcesMtApp.get(tenantIdentifier);
     }
 


### PR DESCRIPTION
If tenant does not exist, master_db will be scanned again for it. But if it not exist after rescan, and somebody try to log in to it, it couse NullPointerException.
So after rescan, there is second check to prevent this.
This can be also problem in brute force attack, if some robot will try load tenant_1 to tenant_18613541864163 there will be so much querys to tenant_db and master_db